### PR TITLE
 Fixed modular markdown include path for ending.md.

### DIFF
--- a/time-based-domain-events/modelling/PITCHME.md
+++ b/time-based-domain-events/modelling/PITCHME.md
@@ -10,4 +10,4 @@
 ---?include=time-based-domain-events/modelling/takeaways.md
 ---?include=time-based-domain-events/modelling/references.md
 ---?include=time-based-domain-events/questions.md
----?include=time-based-domain-events/ending.md
+---?include=time-based-domain-events/modelling/ending.md


### PR DESCRIPTION
@jakubiec  Hi Konrad, I just came across your presentation. Very nice. I spotted a small error right at the end of your deck on a modular markdown include path. This PR  simply fixes that path so your deck renders the included content within `ending.md` as originally intended.

You can preview my version of the slide deck including the updated slide [right here](https://gitpitch.com/gitpitch/ddd-public-materials/gitpitch-patch-1?p=time-based-domain-events/modelling#/48) to see the effect of the changes before your merge.

Hope this helps. And I hope you are enjoying using GitPitch. 

Cheers, David.

